### PR TITLE
cmd/gd: fix version error log

### DIFF
--- a/cmd/gd/main.go
+++ b/cmd/gd/main.go
@@ -154,7 +154,7 @@ func wrap() error {
 	}
 	godot, err := useGodot()
 	if err != nil {
-		return fmt.Errorf("gd requires Godot v%s to be installed as a binary at $GOPATH/bin/godot-%s: %w", version, err)
+		return fmt.Errorf("gd requires Godot v%s to be installed as a binary at $GOPATH/bin/godot-%s: %w", version, version, err)
 	}
 	wd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
Fix for a minor issue with error logs about missing versions (caught by go vet).