### PR TITLE
Object Method Call

### DIFF
--- a/variant/Object/global.go
+++ b/variant/Object/global.go
@@ -31,7 +31,8 @@ func HasMethod(object Any, method string) bool { //gd:Object.has_method
 	return object.AsObject()[0].HasMethod(gd.NewStringName(method))
 }
 
-func CallV(object Any, method string, args ...any) any { //gd:Object.callv
+// Call calls the method on the object and returns the result.
+func Call(object Any, method string, args ...any) any { //gd:Object.call
 	array := gd.NewArray()
 	for _, arg := range args {
 		array.PushBack(gd.NewVariant(arg))

--- a/variant/Object/global.go
+++ b/variant/Object/global.go
@@ -30,3 +30,12 @@ func Get(object Any, property string) any { //gd:Object.get
 func HasMethod(object Any, method string) bool { //gd:Object.has_method
 	return object.AsObject()[0].HasMethod(gd.NewStringName(method))
 }
+
+func CallV(object Any, method string, args ...any) any { //gd:Object.callv
+	array := gd.NewArray()
+	for _, arg := range args {
+		array.PushBack(gd.NewVariant(arg))
+	}
+
+	return object.AsObject()[0].Callv(gd.NewStringName(method), array)
+}


### PR DESCRIPTION
Its a `callv`, but I think its better be `call`, but here is no `Call` method in internal, only `Callv`.
Also where can I get a description formated appropriate?

Tested with code like this:
```go
Object.CallV(myObj, "test", 418, "teapot", 3.14)
```

```go
func (n *Myobj) Test(arg1 int, arg2 string, arg3 float64) {
	println(arg1)
	println(arg2)
	println(arg3)
}
```