### PR TITLE
Fix Angle.Difference implementation

### DIFF
--- a/variant/Angle/angle.go
+++ b/variant/Angle/angle.go
@@ -75,9 +75,8 @@ func Asinh[X Float.Any](x X) Radians { //gd:asinh
 // Difference returns the difference between the two angles, in the range of [-Pi, +Pi].
 // When from and to are opposite, returns -Pi if from is smaller than to, or Pi otherwise.
 func Difference(from, to Radians) Radians { //gd:angle_difference
-	d := float32(to) - float32(from)
-	wrapped := Float.Mod(d + float32(Pi), float32(Tau)) - float32(Pi)
-	return Radians(wrapped)
+	diff := Float.Mod(to - from, Tau)
+	return Float.Mod(2*diff, Tau) - diff
 }
 
 // Tan returns the tangent of angle x in radians.

--- a/variant/Angle/angle.go
+++ b/variant/Angle/angle.go
@@ -75,8 +75,9 @@ func Asinh[X Float.Any](x X) Radians { //gd:asinh
 // Difference returns the difference between the two angles, in the range of [-Pi, +Pi].
 // When from and to are opposite, returns -Pi if from is smaller than to, or Pi otherwise.
 func Difference(from, to Radians) Radians { //gd:angle_difference
-	difference := Float.Mod(from, to)
-	return Float.Mod(2*difference, Tau) - difference
+	d := float32(to) - float32(from)
+	wrapped := Float.Mod(d + float32(Pi), float32(Tau)) - float32(Pi)
+	return Radians(wrapped)
 }
 
 // Tan returns the tangent of angle x in radians.

--- a/variant/Angle/angle_test.go
+++ b/variant/Angle/angle_test.go
@@ -1,0 +1,40 @@
+package Angle
+
+import (
+	"testing"
+	"math"
+)
+
+const epsilon = 1e-5
+
+func almostEqual(a, b float32) bool {
+	return math.Abs(float64(a-b)) < epsilon
+}
+
+func TestDifference(t *testing.T) {
+	cases := []struct {
+		name       string
+		from, to   float32 // input angles in radians
+		want       float32 // expected signed difference in [–π, +π]
+	}{
+		{"zero→zero",            0,               0,                   0},
+		{"0→π/2",                0,               math.Pi/2,           math.Pi/2},
+		{"π/2→0",                math.Pi/2,       0,                  -math.Pi/2},
+		{"wrap past +π",         3*math.Pi/4,     -3*math.Pi/4,        math.Pi/2},
+		{"wrap past –π",        -3*math.Pi/4,      3*math.Pi/4,       -math.Pi/2},
+		{"exact opp 0→π",        0,               math.Pi,            -math.Pi},
+		{"exact opp π→0",        math.Pi,         0,                    math.Pi},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Difference(Radians(c.from), Radians(c.to))
+			if !almostEqual(float32(got), c.want) {
+				t.Fatalf(
+					"Difference(%.3f, %.3f) = %.5f; want %.5f",
+					c.from, c.to, float32(got), c.want,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The delta was not being calculated correctly resulting in NaN output

The godot implementation:
```cpp
double angle_difference(double p_from, double p_to) {
	double difference = fmod(p_to - p_from, TAU);
	return fmod(2.0 * difference, TAU) - difference;
}
```