### PR TITLE
File Open Fix

### DIFF
--- a/classdb/register_class.go
+++ b/classdb/register_class.go
@@ -2,6 +2,7 @@ package classdb
 
 import (
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -262,6 +263,10 @@ func init() {
 			path := gd.Global.GetLibraryPath(gd.Global.ExtensionToken)
 			data, err := os.Open(filepath.Join(filepath.Dir(path.String()), "library_documentation.xml"))
 			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					return
+				}
+
 				EngineClass.Raise(err)
 			}
 			var dec = xml.NewDecoder(data)


### PR DESCRIPTION
Seems like `library_documentation.xml` does not generated in some cases, works without it. Fix to not show a errors about it:

```
ERROR: open /game/library_documentation.xml: no such file or directory
   at: push_error (core/variant/variant_utility.cpp:1098)
ERROR: failed to unmarshal library documentation: invalid argument
   at: push_error (core/variant/variant_utility.cpp:1098)
```