### PR TITLE
Make Int.Snapped consistent with godot Snappedi

### DIFF
--- a/variant/Int/int.go
+++ b/variant/Int/int.go
@@ -75,7 +75,7 @@ func Posmod[T Any](x, y T) T { //gd:posmod
 // floating point number to an arbitrary number of decimals.
 func Snapped[X Any](val, by X) X { //gd:snappedi
 	if by != 0 {
-		val = (val / by) * by
+		val = X(Float.Floor(Float.X(val)/Float.X(by)+Float.X(0.5)) * Float.X(by))
 	}
 	return val
 }

--- a/variant/Int/int.go
+++ b/variant/Int/int.go
@@ -73,11 +73,12 @@ func Posmod[T Any](x, y T) T { //gd:posmod
 
 // Snapped returns the multiple of step that is the closest to x. This can also be used to round a
 // floating point number to an arbitrary number of decimals.
-func Snapped[X Any](val, by X) X { //gd:snappedi
+func Snapped[X Any, F ~float32 | ~float64 | Any](val F, by X) X { //gd:snappedi
 	if by != 0 {
-		val = X(Float.Floor(Float.X(val)/Float.X(by)+Float.X(0.5)) * Float.X(by))
+		snapped := Float.Snapped(Float.X(val), Float.X(by))
+		return X(snapped)
 	}
-	return val
+	return X(val)
 }
 
 // Wrap value between min and max. Can be used for creating loop-alike behavior or

--- a/variant/Int/int_test.go
+++ b/variant/Int/int_test.go
@@ -1,0 +1,65 @@
+package Int
+
+import (
+	"testing"
+)
+
+func TestSnapped_PositiveCloseLower(t *testing.T) {
+	if got := Snapped(7, 5); got != 5 {
+		t.Errorf("Snapped(7, 5) = %d, expected %d", got, 5)
+	}
+}
+
+func TestSnapped_PositiveCloseUpper(t *testing.T) {
+	if got := Snapped(8, 5); got != 10 {
+		t.Errorf("Snapped(8, 5) = %d, expected %d", got, 10)
+	}
+}
+
+func TestSnapped_PositiveExactlyHalfway(t *testing.T) {
+	if got := Snapped(15, 10); got != 20 {
+		t.Errorf("Snapped(15, 10) = %d, expected %d", got, 20)
+	}
+}
+
+func TestSnapped_NegativeCloserMoreNegative(t *testing.T) {
+	if got := Snapped(-8, 5); got != -10 {
+		t.Errorf("Snapped(-8, 5) = %d, expected %d", got, -10)
+	}
+}
+
+func TestSnapped_NegativeCloserLessNegative(t *testing.T) {
+	if got := Snapped(-3, 5); got != -5 {
+		t.Errorf("Snapped(-3, 5) = %d, expected %d", got, -5)
+	}
+}
+
+func TestSnapped_ZeroValue(t *testing.T) {
+	if got := Snapped(0, 5); got != 0 {
+		t.Errorf("Snapped(0, 5) = %d, expected %d", got, 0)
+	}
+}
+
+func TestSnapped_AlreadyMultiple(t *testing.T) {
+	if got := Snapped(10, 5); got != 10 {
+		t.Errorf("Snapped(10, 5) = %d, expected %d", got, 10)
+	}
+}
+
+func TestSnapped_StepSizeOne(t *testing.T) {
+	if got := Snapped(7, 1); got != 7 {
+		t.Errorf("Snapped(7, 1) = %d, expected %d", got, 7)
+	}
+}
+
+func TestSnapped_SmallStepSize(t *testing.T) {
+	if got := Snapped(8, 3); got != 9 {
+		t.Errorf("Snapped(8, 3) = %d, expected %d", got, 9)
+	}
+}
+
+func TestSnapped_LargeValues(t *testing.T) {
+	if got := Snapped(127, 25); got != 125 {
+		t.Errorf("Snapped(127, 25) = %d, expected %d", got, 125)
+	}
+}


### PR DESCRIPTION
Hi,

in my project, I'm using the `snappedi` function a lot. In the current gd graphics variant package implementation, `Float.Snapped` uses the same implementation as godot: https://github.com/godotengine/godot/blob/2dd26a027a99633231184616d4dd287bbdd1c0a3/core/math/math_funcs.cpp#L121 .

However, `Int.Snapped` (and subsequently `VectorX.Snappedi`)  uses a different implementation, which does an integer division and truncates the result:

```go
func Snapped[X Any](val, by X) X { //gd:snappedi
	if by != 0 {
		val = (val / by) * by
	}
	return val
}
```

This yields wrong results when trying to use the `snappedi` function to align coordinates to a grid (in my use case, I use it to calculate the position of a chunk a voxel belongs to). I'd like to replace it with the same implementation used in `Float.Snapped`:

```go
func Snapped[X Any](val, by X) X { //gd:snappedi
	if by != 0 {
		val = X(Float.Floor(Float.X(val)/Float.X(by)+Float.X(0.5)) * Float.X(by))
	}
	return val
}
```

In Godot, this is done the same way.

Here is a semi useless comparison table generated by claude:

## Test Comparison Table

| Test Case | Input (val, by) | Snapped Result | Legacy Result | Difference? | Description |
|-----------|----------------|----------------|---------------|-------------|-------------|
| Close to lower multiple | (7, 5) | 5 | 5 | ❌ No | Both agree when value is closer to lower multiple |
| Close to upper multiple | (8, 5) | 10 | 5 | ✅ Yes | Snapped correctly rounds to nearest, legacy truncates |
| Exactly halfway (positive) | (15, 10) | 20 | 10 | ✅ Yes | Snapped rounds halfway cases away from zero, legacy truncates |
| Negative close to more negative | (-8, 5) | -10 | -5 | ✅ Yes | Snapped correctly handles negative values, legacy truncates toward zero |
| Negative close to less negative | (-3, 5) | -5 | 0 | ✅ Yes | Snapped correctly rounds negative values, legacy truncates toward zero |
| Exactly halfway (negative) | (-15, 10) | -10 | -10 | ❌ No | Both happen to match but for different reasons |
| Positive value, negative step | (8, -5) | 10 | 5 | ✅ Yes | Different behavior with negative step |
| Zero value | (0, 5) | 0 | 0 | ❌ No | Both functions handle zero correctly |
| Value already multiple | (10, 5) | 10 | 10 | ❌ No | Both functions handle exact multiples correctly |
| Step size 1 | (7, 1) | 7 | 7 | ❌ No | Both functions handle step size 1 correctly |
