### PR TITLE
Add Transform3D.TransformAABB

### DIFF
--- a/variant/Transform3D/matrix.go
+++ b/variant/Transform3D/matrix.go
@@ -2,6 +2,7 @@
 package Transform3D
 
 import (
+	"graphics.gd/variant/AABB"
 	"graphics.gd/variant/Angle"
 	"graphics.gd/variant/Basis"
 	"graphics.gd/variant/Float"
@@ -250,5 +251,116 @@ func Transform(v Vector3.XYZ, t BasisOrigin) Vector3.XYZ { //gd:Transform3D*Vect
 		X: t.Basis.X.X*v.X + t.Basis.Y.X*v.Y + t.Basis.Z.X*v.Z + t.Origin.X,
 		Y: t.Basis.X.Y*v.X + t.Basis.Y.Y*v.Y + t.Basis.Z.Y*v.Z + t.Origin.Y,
 		Z: t.Basis.X.Z*v.X + t.Basis.Y.Z*v.Y + t.Basis.Z.Z*v.Z + t.Origin.Z,
+	}
+}
+
+func TransformAabb(aabb AABB.PositionSize, t BasisOrigin) AABB.PositionSize { //gd:Transform3D*AABB
+	/* https://dev.theomader.com/transform-bounding-boxes/ */
+	min := aabb.Position
+	max := Vector3.Add(aabb.Position, aabb.Size)
+	var tmin, tmax Vector3.XYZ
+
+	tmin.X = t.Origin.X
+	tmax.X = t.Origin.X
+
+	e := t.Basis.X.X * min.X
+	f := t.Basis.X.X * max.X
+	if e < f {
+		tmin.X += e
+		tmax.X += f
+	} else {
+		tmin.X += f
+		tmax.X += e
+	}
+
+	e = t.Basis.Y.X * min.Y
+	f = t.Basis.Y.X * max.Y
+	if e < f {
+		tmin.X += e
+		tmax.X += f
+	} else {
+		tmin.X += f
+		tmax.X += e
+	}
+
+	e = t.Basis.Z.X * min.Z
+	f = t.Basis.Z.X * max.Z
+	if e < f {
+		tmin.X += e
+		tmax.X += f
+	} else {
+		tmin.X += f
+		tmax.X += e
+	}
+
+	tmin.Y = t.Origin.Y
+	tmax.Y = t.Origin.Y
+
+	e = t.Basis.X.Y * min.X
+	f = t.Basis.X.Y * max.X
+	if e < f {
+		tmin.Y += e
+		tmax.Y += f
+	} else {
+		tmin.Y += f
+		tmax.Y += e
+	}
+
+	e = t.Basis.Y.Y * min.Y
+	f = t.Basis.Y.Y * max.Y
+	if e < f {
+		tmin.Y += e
+		tmax.Y += f
+	} else {
+		tmin.Y += f
+		tmax.Y += e
+	}
+
+	e = t.Basis.Z.Y * min.Z
+	f = t.Basis.Z.Y * max.Z
+	if e < f {
+		tmin.Y += e
+		tmax.Y += f
+	} else {
+		tmin.Y += f
+		tmax.Y += e
+	}
+
+	tmin.Z = t.Origin.Z
+	tmax.Z = t.Origin.Z
+
+	e = t.Basis.X.Z * min.X
+	f = t.Basis.X.Z * max.X
+	if e < f {
+		tmin.Z += e
+		tmax.Z += f
+	} else {
+		tmin.Z += f
+		tmax.Z += e
+	}
+
+	e = t.Basis.Y.Z * min.Y
+	f = t.Basis.Y.Z * max.Y
+	if e < f {
+		tmin.Z += e
+		tmax.Z += f
+	} else {
+		tmin.Z += f
+		tmax.Z += e
+	}
+
+	e = t.Basis.Z.Z * min.Z
+	f = t.Basis.Z.Z * max.Z
+	if e < f {
+		tmin.Z += e
+		tmax.Z += f
+	} else {
+		tmin.Z += f
+		tmax.Z += e
+	}
+
+	return AABB.PositionSize{
+		Position: tmin,
+		Size:     Vector3.Sub(tmax, tmin),
 	}
 }

--- a/variant/Transform3D/matrix.go
+++ b/variant/Transform3D/matrix.go
@@ -254,7 +254,7 @@ func Transform(v Vector3.XYZ, t BasisOrigin) Vector3.XYZ { //gd:Transform3D*Vect
 	}
 }
 
-func TransformAabb(aabb AABB.PositionSize, t BasisOrigin) AABB.PositionSize { //gd:Transform3D*AABB
+func TransformAABB(aabb AABB.PositionSize, t BasisOrigin) AABB.PositionSize { //gd:Transform3D*AABB
 	/* https://dev.theomader.com/transform-bounding-boxes/ */
 	min := aabb.Position
 	max := Vector3.Add(aabb.Position, aabb.Size)

--- a/variant/Transform3D/matrix_test.go
+++ b/variant/Transform3D/matrix_test.go
@@ -29,21 +29,21 @@ func aabbApproxEqual(a, b AABB.PositionSize, tolerance Float.X) bool {
 		vector3ApproxEqual(a.Size, b.Size, tolerance)
 }
 
-func TestTransformAabb_Identity(t *testing.T) {
+func TestTransformAABB_Identity(t *testing.T) {
 	// Test that identity transform doesn't change the AABB
 	aabb := AABB.PositionSize{
 		Position: Vector3.XYZ{X: 1, Y: 2, Z: 3},
 		Size:     Vector3.XYZ{X: 4, Y: 5, Z: 6},
 	}
 
-	result := Transform3D.TransformAabb(aabb, Transform3D.Identity)
+	result := Transform3D.TransformAABB(aabb, Transform3D.Identity)
 
 	if !aabbApproxEqual(result, aabb, 1e-6) {
 		t.Errorf("Identity transform should not change AABB. Expected %+v, got %+v", aabb, result)
 	}
 }
 
-func TestTransformAabb_Translation(t *testing.T) {
+func TestTransformAABB_Translation(t *testing.T) {
 	// Test pure translation
 	aabb := AABB.PositionSize{
 		Position: Vector3.XYZ{X: 0, Y: 0, Z: 0},
@@ -56,7 +56,7 @@ func TestTransformAabb_Translation(t *testing.T) {
 		Origin: translation,
 	}
 
-	result := Transform3D.TransformAabb(aabb, transform)
+	result := Transform3D.TransformAABB(aabb, transform)
 	expected := AABB.PositionSize{
 		Position: translation,
 		Size:     aabb.Size,
@@ -67,7 +67,7 @@ func TestTransformAabb_Translation(t *testing.T) {
 	}
 }
 
-func TestTransformAabb_UniformScale(t *testing.T) {
+func TestTransformAABB_UniformScale(t *testing.T) {
 	// Test uniform scaling
 	aabb := AABB.PositionSize{
 		Position: Vector3.XYZ{X: 1, Y: 1, Z: 1},
@@ -84,7 +84,7 @@ func TestTransformAabb_UniformScale(t *testing.T) {
 		Origin: Vector3.Zero,
 	}
 
-	result := Transform3D.TransformAabb(aabb, transform)
+	result := Transform3D.TransformAABB(aabb, transform)
 	expected := AABB.PositionSize{
 		Position: Vector3.XYZ{X: 2, Y: 2, Z: 2}, // Position scaled
 		Size:     Vector3.XYZ{X: 4, Y: 4, Z: 4}, // Size scaled
@@ -95,7 +95,7 @@ func TestTransformAabb_UniformScale(t *testing.T) {
 	}
 }
 
-func TestTransformAabb_Rotation90Z(t *testing.T) {
+func TestTransformAABB_Rotation90Z(t *testing.T) {
 	// Test 90-degree rotation around Z-axis
 	aabb := AABB.PositionSize{
 		Position: Vector3.XYZ{X: 1, Y: 0, Z: 0},
@@ -112,7 +112,7 @@ func TestTransformAabb_Rotation90Z(t *testing.T) {
 		Origin: Vector3.Zero,
 	}
 
-	result := Transform3D.TransformAabb(aabb, transform)
+	result := Transform3D.TransformAABB(aabb, transform)
 
 	// After rotation, the AABB should encompass the rotated box
 	// Original box spans from (1,0,0) to (2,1,1)
@@ -128,7 +128,7 @@ func TestTransformAabb_Rotation90Z(t *testing.T) {
 	}
 }
 
-func TestTransformAabb_NegativeScale(t *testing.T) {
+func TestTransformAABB_NegativeScale(t *testing.T) {
 	// Test negative scaling (mirroring)
 	aabb := AABB.PositionSize{
 		Position: Vector3.XYZ{X: 1, Y: 1, Z: 1},
@@ -145,7 +145,7 @@ func TestTransformAabb_NegativeScale(t *testing.T) {
 		Origin: Vector3.Zero,
 	}
 
-	result := Transform3D.TransformAabb(aabb, transform)
+	result := Transform3D.TransformAABB(aabb, transform)
 
 	// Original box spans from (1,1,1) to (3,3,3)
 	// After X flip: (1,1,1) -> (-1,1,1), (3,3,3) -> (-3,3,3)

--- a/variant/Transform3D/matrix_test.go
+++ b/variant/Transform3D/matrix_test.go
@@ -1,0 +1,161 @@
+package Transform3D_test
+
+import (
+	"math"
+	"testing"
+
+	"graphics.gd/variant/AABB"
+	"graphics.gd/variant/Basis"
+	"graphics.gd/variant/Float"
+	"graphics.gd/variant/Transform3D"
+	"graphics.gd/variant/Vector3"
+)
+
+// Helper function to check if two float values are approximately equal
+func approxEqual(a, b Float.X, tolerance Float.X) bool {
+	return math.Abs(float64(a-b)) < float64(tolerance)
+}
+
+// Helper function to check if two Vector3 values are approximately equal
+func vector3ApproxEqual(a, b Vector3.XYZ, tolerance Float.X) bool {
+	return approxEqual(a.X, b.X, tolerance) &&
+		approxEqual(a.Y, b.Y, tolerance) &&
+		approxEqual(a.Z, b.Z, tolerance)
+}
+
+// Helper function to check if two AABB values are approximately equal
+func aabbApproxEqual(a, b AABB.PositionSize, tolerance Float.X) bool {
+	return vector3ApproxEqual(a.Position, b.Position, tolerance) &&
+		vector3ApproxEqual(a.Size, b.Size, tolerance)
+}
+
+func TestTransformAabb_Identity(t *testing.T) {
+	// Test that identity transform doesn't change the AABB
+	aabb := AABB.PositionSize{
+		Position: Vector3.XYZ{X: 1, Y: 2, Z: 3},
+		Size:     Vector3.XYZ{X: 4, Y: 5, Z: 6},
+	}
+
+	result := Transform3D.TransformAabb(aabb, Transform3D.Identity)
+
+	if !aabbApproxEqual(result, aabb, 1e-6) {
+		t.Errorf("Identity transform should not change AABB. Expected %+v, got %+v", aabb, result)
+	}
+}
+
+func TestTransformAabb_Translation(t *testing.T) {
+	// Test pure translation
+	aabb := AABB.PositionSize{
+		Position: Vector3.XYZ{X: 0, Y: 0, Z: 0},
+		Size:     Vector3.XYZ{X: 2, Y: 2, Z: 2},
+	}
+
+	translation := Vector3.XYZ{X: 10, Y: 20, Z: 30}
+	transform := Transform3D.BasisOrigin{
+		Basis:  Basis.Identity,
+		Origin: translation,
+	}
+
+	result := Transform3D.TransformAabb(aabb, transform)
+	expected := AABB.PositionSize{
+		Position: translation,
+		Size:     aabb.Size,
+	}
+
+	if !aabbApproxEqual(result, expected, 1e-6) {
+		t.Errorf("Translation transform failed. Expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestTransformAabb_UniformScale(t *testing.T) {
+	// Test uniform scaling
+	aabb := AABB.PositionSize{
+		Position: Vector3.XYZ{X: 1, Y: 1, Z: 1},
+		Size:     Vector3.XYZ{X: 2, Y: 2, Z: 2},
+	}
+
+	scale := Float.X(2.0)
+	transform := Transform3D.BasisOrigin{
+		Basis: Basis.XYZ{
+			X: Vector3.XYZ{X: scale, Y: 0, Z: 0},
+			Y: Vector3.XYZ{X: 0, Y: scale, Z: 0},
+			Z: Vector3.XYZ{X: 0, Y: 0, Z: scale},
+		},
+		Origin: Vector3.Zero,
+	}
+
+	result := Transform3D.TransformAabb(aabb, transform)
+	expected := AABB.PositionSize{
+		Position: Vector3.XYZ{X: 2, Y: 2, Z: 2}, // Position scaled
+		Size:     Vector3.XYZ{X: 4, Y: 4, Z: 4}, // Size scaled
+	}
+
+	if !aabbApproxEqual(result, expected, 1e-6) {
+		t.Errorf("Uniform scale transform failed. Expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestTransformAabb_Rotation90Z(t *testing.T) {
+	// Test 90-degree rotation around Z-axis
+	aabb := AABB.PositionSize{
+		Position: Vector3.XYZ{X: 1, Y: 0, Z: 0},
+		Size:     Vector3.XYZ{X: 1, Y: 1, Z: 1},
+	}
+
+	// 90-degree rotation around Z-axis: X becomes Y, Y becomes -X
+	transform := Transform3D.BasisOrigin{
+		Basis: Basis.XYZ{
+			X: Vector3.XYZ{X: 0, Y: 1, Z: 0},  // Original X axis becomes Y
+			Y: Vector3.XYZ{X: -1, Y: 0, Z: 0}, // Original Y axis becomes -X
+			Z: Vector3.XYZ{X: 0, Y: 0, Z: 1},  // Z unchanged
+		},
+		Origin: Vector3.Zero,
+	}
+
+	result := Transform3D.TransformAabb(aabb, transform)
+
+	// After rotation, the AABB should encompass the rotated box
+	// Original box spans from (1,0,0) to (2,1,1)
+	// After rotation: (1,0,0) -> (0,1,0), (2,1,1) -> (-1,2,1)
+	// So the AABB should span from (-1,1,0) to (0,2,1)
+	expected := AABB.PositionSize{
+		Position: Vector3.XYZ{X: -1, Y: 1, Z: 0},
+		Size:     Vector3.XYZ{X: 1, Y: 1, Z: 1},
+	}
+
+	if !aabbApproxEqual(result, expected, 1e-6) {
+		t.Errorf("90-degree Z rotation failed. Expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestTransformAabb_NegativeScale(t *testing.T) {
+	// Test negative scaling (mirroring)
+	aabb := AABB.PositionSize{
+		Position: Vector3.XYZ{X: 1, Y: 1, Z: 1},
+		Size:     Vector3.XYZ{X: 2, Y: 2, Z: 2},
+	}
+
+	// Mirror across X-axis (flip X)
+	transform := Transform3D.BasisOrigin{
+		Basis: Basis.XYZ{
+			X: Vector3.XYZ{X: -1, Y: 0, Z: 0}, // Flip X
+			Y: Vector3.XYZ{X: 0, Y: 1, Z: 0},  // Y unchanged
+			Z: Vector3.XYZ{X: 0, Y: 0, Z: 1},  // Z unchanged
+		},
+		Origin: Vector3.Zero,
+	}
+
+	result := Transform3D.TransformAabb(aabb, transform)
+
+	// Original box spans from (1,1,1) to (3,3,3)
+	// After X flip: (1,1,1) -> (-1,1,1), (3,3,3) -> (-3,3,3)
+	// AABB should span from (-3,1,1) to (-1,3,3)
+	expected := AABB.PositionSize{
+		Position: Vector3.XYZ{X: -3, Y: 1, Z: 1},
+		Size:     Vector3.XYZ{X: 2, Y: 2, Z: 2},
+	}
+
+	if !aabbApproxEqual(result, expected, 1e-6) {
+		t.Errorf("Negative scale (mirror) failed. Expected %+v, got %+v", expected, result)
+	}
+}


### PR DESCRIPTION
This adds a method to apply a 3d transform to an AABB.

The implementation is ported from the godot c++ implementation. That contains a dead link to the web page the implementation is based on; I've kept it anyways. The c++ code is much shorter than the go version because it uses dynamic indexes to access the X, Y, Z dimensions.

The unit tests are AI generated, I'm not sure if you want to have them included. I only reviewed them. I've tested the implementation manually, it yields the expected results in my SDF code.

<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/df940016-9f85-40c1-b2bc-a2c326c517bb" />
